### PR TITLE
Removed +2 hours when creating instant value

### DIFF
--- a/saml_utils.js
+++ b/saml_utils.js
@@ -44,7 +44,7 @@ SAML.prototype.generateUniqueID = function () {
 
 SAML.prototype.generateInstant = function () {
   var date = new Date();
-  return date.getUTCFullYear() + '-' + ('0' + (date.getUTCMonth()+1)).slice(-2) + '-' + ('0' + date.getUTCDate()).slice(-2) + 'T' + ('0' + (date.getUTCHours()+2)).slice(-2) + ":" + ('0' + date.getUTCMinutes()).slice(-2) + ":" + ('0' + date.getUTCSeconds()).slice(-2) + "Z";
+  return date.getUTCFullYear() + '-' + ('0' + (date.getUTCMonth()+1)).slice(-2) + '-' + ('0' + date.getUTCDate()).slice(-2) + 'T' + ('0' + (date.getUTCHours())).slice(-2) + ":" + ('0' + date.getUTCMinutes()).slice(-2) + ":" + ('0' + date.getUTCSeconds()).slice(-2) + "Z";
 };
 
 SAML.prototype.signRequest = function (xml) {


### PR DESCRIPTION
I was tripped up with the +2 hour offset when the Instant value is generated. This PR removes the +2 so that the time should be UTC.